### PR TITLE
Use display_name instead of label

### DIFF
--- a/src/scripts/service.list.all.js
+++ b/src/scripts/service.list.all.js
@@ -68,14 +68,14 @@ module.exports = (robot) => {
 				color: palette.normal
 			};
 			attachment.fields = [
-				{title: service.label, value: service.description, short: true}
+				{title: service.display_name, value: service.description, short: true}
 			];
 			return attachment;
 		});
 
 		// Add the list of service names to the global cache for Natural Lang.
 		var serviceNames = cf.serviceCache.map(function(service){
-			return service.label;
+			return service.display_name;
 		});
 		nlcconfig.updateGlobalParameterValues('IBMcloudServiceManagment_servicename', serviceNames);
 


### PR DESCRIPTION
Small change to use `display_name` instead of `label` when listing all services. This is consistent with `service-suggest`.

Note, `service list space` lists the `label` because the response we get from `getSummary` does not include the `display_name`. We can either iterate through the `cf.serviceCache` and pull out the `display_name` for each or open an issue against `cf-client` to include it in their response. 

@clanzen What do you think?
